### PR TITLE
handle react memo

### DIFF
--- a/src/__tests__/radium-test.js
+++ b/src/__tests__/radium-test.js
@@ -77,6 +77,27 @@ describe('Radium blackbox tests', () => {
     expect(div.style.padding).to.equal('9px');
   });
 
+  it('merges nested styles in memo components', () => {
+    const TestComponent = Radium(
+      React.memo(() => (
+        <div
+          style={[
+            [{color: 'blue'}, [{height: '2px', padding: '9px'}]],
+            {background: 'red'}
+          ]}
+        />
+      ))
+    );
+
+    const output = renderFcIntoDocument(<TestComponent />);
+    const div = getElement(output, 'div');
+
+    expect(div.style.color).to.equal('blue');
+    expect(div.style.background).to.equal('red');
+    expect(div.style.height).to.equal('2px');
+    expect(div.style.padding).to.equal('9px');
+  });
+
   it('merges nested styles and forwards ref in function components with forwardRef', () => {
     const TestComponent = Radium(
       React.forwardRef((props, ref) => (

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -379,10 +379,10 @@ export default function enhanceWithRadium(
     ReactMemoSymbol &&
     configOrComposedComponent.$$typeof === ReactMemoSymbol
   ) {
-    return createEnhancedFunctionComponent(
-      configOrComposedComponent.type,
-      config
+    const EnhancedComponent = memo(
+      createEnhancedFunctionComponent(configOrComposedComponent.type, config)
     );
+    return hoistStatics(EnhancedComponent, configOrComposedComponent);
   }
 
   if (typeof configOrComposedComponent !== 'function') {

--- a/src/enhancer.js
+++ b/src/enhancer.js
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useRef,
   useEffect,
+  memo,
   forwardRef
 } from 'react';
 import PropTypes from 'prop-types';
@@ -358,6 +359,7 @@ function createComposedFromNativeClass(ComposedComponent: constructor) {
 }
 
 const ReactForwardRefSymbol = (forwardRef(() => null): any).$$typeof;
+const ReactMemoSymbol = (memo(() => null): any).$$typeof;
 
 export default function enhanceWithRadium(
   configOrComposedComponent: Class<any> | constructor | Function | Object,
@@ -369,6 +371,16 @@ export default function enhanceWithRadium(
   ) {
     return createEnhancedFunctionComponent(
       configOrComposedComponent.render,
+      config
+    );
+  }
+
+  if (
+    ReactMemoSymbol &&
+    configOrComposedComponent.$$typeof === ReactMemoSymbol
+  ) {
+    return createEnhancedFunctionComponent(
+      configOrComposedComponent.type,
       config
     );
   }


### PR DESCRIPTION
radium doesn't handle react.memo components properly

this ensures that they are handled properly, takes the component out, enhacnes it, and re-wraps it in memo.