### PR TITLE
fix displayname hoisting for memo components

### DIFF
--- a/src/__tests__/enhancer-test.js
+++ b/src/__tests__/enhancer-test.js
@@ -238,4 +238,26 @@ describe('Enhancer', () => {
       expect(Enhanced.prototype.hasOwnProperty(key)).to.equal(true);
     });
   });
+
+  it('works with memo components', () => {
+    function HelloWorld() {
+      <div>Hello World</div>;
+    }
+    const MemoComponent = React.memo(HelloWorld);
+    const Enhanced = Enhancer(MemoComponent);
+
+    expect(Enhanced.$$typeof).to.equal((React.memo(() => null): any).$$typeof);
+  });
+
+  it('keeps the displayName for memo components', () => {
+    function HelloWorld() {
+      <div>Hello World</div>;
+    }
+    const MemoComponent = React.memo(HelloWorld);
+    MemoComponent.displayName = 'Foo(HelloWorld)';
+
+    const Enhanced = Enhancer(MemoComponent);
+
+    expect(Enhanced.displayName).to.equal('Foo(HelloWorld)');
+  });
 });


### PR DESCRIPTION
realised 2 changes i made didn't 100% play nicely together and displayName fix didn't work 100% properly for memo components.

moved things around to accomodate